### PR TITLE
add HtmlRenderer

### DIFF
--- a/examples/html-demo.js
+++ b/examples/html-demo.js
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation and others.
+// SPDX-License-Identifier: Apache-2.0
+
+const DocBuilder = require('tiny-attribution-generator').default;
+const HtmlRenderer = require('tiny-attribution-generator/lib/outputs/html')
+  .default;
+const JSONSource = require('tiny-attribution-generator/lib/inputs/json')
+  .default;
+
+const renderer = new HtmlRenderer();
+const builder = new DocBuilder(renderer);
+
+const packageData = JSON.stringify({
+  packages: [
+    {
+      name: 'aabb',
+      version: '1.0.4',
+      license: 'MIT',
+      website: 'https://github.com/testpackage/aabb',
+      copyright: 'Copyright (c) Test copyright'
+    },
+    {
+      name: 'bbcc',
+      version: '1.1.1',
+      license: 'ISC',
+      website: 'https://github.com/testpackage/bbcc'
+    },
+    {
+      name: 'ccdd',
+      version: '1.3.4',
+      license: 'MIT',
+      website: 'https://github.com/testpackage/ccdd',
+      copyright: 'Copyright the holder'
+    },
+  ],
+});
+
+const source = new JSONSource(packageData);
+builder.read(source);
+
+const output = builder.build();
+
+console.log(output);

--- a/outputs/html/index.ts
+++ b/outputs/html/index.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation and others.
+// SPDX-License-Identifier: Apache-2.0
+
+import { LicenseBucket } from "../../structure";
+import OutputRenderer from "../base";
+
+export default class HtmlRenderer implements OutputRenderer<string> {
+  private lines: string[] = [];
+
+  constructor() {}
+
+  render(buckets: LicenseBucket[]): string {
+    this.lines = [];
+
+    this.lines.push('<!doctype html>');
+    this.lines.push('<html lang="en">');
+    this.lines.push('<head>');
+    this.lines.push('<title>OSS Attribution</title>');
+    this.lines.push('<style>pre { white-space: pre-wrap; background: #eee; padding: 24px;}</style>')
+    this.lines.push('</head>');
+    this.lines.push('<body>');
+    this.lines.push('<h1>OSS Attribution</h1>');
+
+    this.lines.push('<ol>');
+    for (const bucket of buckets) {
+      for (const pkg of bucket.packages) {
+        this.lines.push('<li>');
+        this.lines.push('<details>');
+
+        this.lines.push(`<summary>${pkg.name} ${pkg.version} - ${bucket.name}</summary>`);
+
+        if (pkg.website) {
+          this.lines.push(`<p><a href="${pkg.website}">${pkg.website}</a></p>`);
+        }
+
+        if (pkg.copyright) {
+          this.lines.push(`<p>${this.encodeAngleBrackets(pkg.copyright)}</p>`);
+        }
+
+        this.lines.push(`<pre>${this.encodeAngleBrackets(bucket.text)}</pre>`);
+
+        this.lines.push('</details>');
+        this.lines.push('</li>');
+      }
+    }
+    this.lines.push('</ol>');
+
+    this.lines.push('</body>');
+    this.lines.push('</html>');
+
+    const final = this.lines.join('');
+    return final;
+  }
+
+  private encodeAngleBrackets(str: string) {
+    return str.replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;');
+  }
+}


### PR DESCRIPTION
This adds a new HTML output renderer that implements `OutputRenderer<string>` based off the `TextRenderer` implementation

The HTML document that is produced repeats each license text per usage and leverages the [details disclosure element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) to make them collapsible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
