### PR TITLE
set up JsonRenderer for chaining workflows (fixes #4)

### DIFF
--- a/__tests__/outputs/json.test.ts
+++ b/__tests__/outputs/json.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation and others.
+// SPDX-License-Identifier: Apache-2.0
+
+import JsonRenderer from '../../outputs/json';
+
+test('should render json', () => {
+  const jsonRenderer = new JsonRenderer();
+  const licenseBuckets = [
+    {
+      id: '1',
+      text: 'license text',
+      name: 'LIC',
+      tags: [],
+      packages: [
+        {
+          name: 'package1',
+          version: '1.0.0',
+        },
+      ],
+    },
+  ];
+  const output = jsonRenderer.render(licenseBuckets);
+  expect(output).toEqual({
+    packages: [
+      {
+        name: 'package1',
+        version: '1.0.0',
+      },
+    ],
+  });
+});
+
+test('should flatten buckets', () => {
+  const jsonRenderer = new JsonRenderer();
+  const licenseBuckets = [
+    {
+      id: '1',
+      text: 'license text',
+      name: 'LIC',
+      tags: [],
+      packages: [
+        {
+          name: 'package1',
+          version: '1.0.0',
+        },
+      ],
+    },
+    {
+      id: '2',
+      text: 'second license text',
+      name: 'MIT',
+      tags: [],
+      packages: [
+        {
+          name: 'package2',
+          version: '2.0.0',
+        },
+      ],
+    },
+  ];
+  const output = jsonRenderer.render(licenseBuckets);
+  expect(output).toEqual({
+    packages: [
+      {
+        name: 'package1',
+        version: '1.0.0',
+      },
+      {
+        name: 'package2',
+        version: '2.0.0',
+      },
+    ],
+  });
+});

--- a/docbuilder.ts
+++ b/docbuilder.ts
@@ -17,7 +17,7 @@ interface Annotation {
 export default class DocBuilder {
   private buckets = new Map<string, LicenseBucket>();
 
-  constructor(private renderer: OutputRenderer<string>) {}
+  constructor(private renderer: OutputRenderer<any>) {}
 
   addPackage(pkg: Package) {
     // add an identifier if not present

--- a/examples/json-demo.js
+++ b/examples/json-demo.js
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation and others.
+// SPDX-License-Identifier: Apache-2.0
+
+const DocBuilder = require('../lib/docbuilder').default;
+const TextRenderer = require('../lib/outputs/text').default;
+const JsonRenderer = require('../lib/outputs/json').default;
+const JSONSource = require('../lib/inputs/json').default;
+
+const jsonRenderer = new JsonRenderer();
+const textRenderer = new TextRenderer();
+const jsonBuilder = new DocBuilder(jsonRenderer);
+const textBuilder = new DocBuilder(textRenderer);
+
+// Initial package data
+const packageData = JSON.stringify({
+  packages: [
+    {
+      name: 'aabb',
+      version: '1.0.4',
+      license: 'MIT',
+      website: 'https://github.com/testpackage/aabb',
+      copyrights: ['Copyright (c) Test copyright'],
+    },
+    {
+      name: 'bbcc',
+      version: '1.1.1',
+      license: 'ISC',
+      website: 'https://github.com/testpackage/bbcc',
+    },
+  ],
+});
+
+const jsonSource = new JSONSource(packageData);
+jsonBuilder.read(jsonSource);
+
+// Use the JsonRenderer to build
+const jsonOutput = jsonBuilder.build();
+
+// Push a new package onto the output of the previous builder
+jsonOutput.packages.push({
+  name: 'ccdd',
+  version: '2.0.0',
+  license: 'MIT',
+  website: 'https://github.com/testpackage/ccdd',
+});
+
+// Build the final result with the TextRenderer
+const nextPackageData = JSON.stringify(jsonOutput);
+const textSource = new JSONSource(nextPackageData);
+textBuilder.read(textSource);
+
+const output = textBuilder.build();
+
+console.log(output);

--- a/outputs/json/index.ts
+++ b/outputs/json/index.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation and others.
+// SPDX-License-Identifier: Apache-2.0
+
+import OutputRenderer from '../base';
+import { LicenseBucket } from '../../structure';
+
+/*
+ * This is used to facilitate chaining across different toolsets
+ */
+export default class JsonRenderer implements OutputRenderer<any> {
+  constructor() {}
+
+  render(buckets: LicenseBucket[]): any {
+    return {
+      packages: buckets.map(x => x.packages).reduce((a, b) => {
+        return a.concat(b);
+      }, []),
+    };
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
#4 

*Description of changes:*

- Adds a new output renderer that can be plugged into workflows.
- Had to update the base from `OutputRenderer<string>` to `OutputRenderer<any>`  to allow it to flow through
- I flattened the buckets in the `JsonRenderer` so that you can push right onto the output and create a new input directly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
