### PR TITLE
add simpler template renderer

### DIFF
--- a/outputs/template/index.ts
+++ b/outputs/template/index.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation and others.
+// SPDX-License-Identifier: Apache-2.0
+
+import { LicenseBucket } from '../../structure';
+import OutputRenderer from '../base';
+import { compile } from 'handlebars';
+
+export default class TemplateRenderer implements OutputRenderer<string> {
+  constructor(private template: string) {}
+
+  render(buckets: LicenseBucket[]): string {
+    const compiler = compile(this.template);
+    const result = compiler({ buckets });
+    return result;
+  }
+}


### PR DESCRIPTION
*Description of changes:*

An `OutputRenderer<string>` that requires a template is passed in to construct and does not make any assumptions about the output format.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
