### PR TITLE
add PackageLockSource

### DIFF
--- a/__tests__/inputs/packagelock.test.ts
+++ b/__tests__/inputs/packagelock.test.ts
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation and others.
+// SPDX-License-Identifier: Apache-2.0
+
+import PackageLockSource from '../../inputs/packagelock';
+
+test('should get package by key', () => {
+  const source = new PackageLockSource(`
+  {
+    "name": "module",
+    "version": "0.0.1",
+    "dependencies": {
+      "Test Package": {
+        "version": "1.0.0"
+      }
+    }
+  }`);
+
+  const result = source.getPackage('Test Package 1.0.0');
+  expect(result).toBeTruthy();
+  expect(result).toEqual({
+    name: 'Test Package',
+    version: '1.0.0',
+    text: '_',
+  });
+});
+
+test('should not get package by bad key', () => {
+  const source = new PackageLockSource(`
+  {
+    "name": "module",
+    "version": "0.0.1",
+    "dependencies": {
+      "Test Package": {
+        "version": "1.0.0"
+      }
+    }
+  }`);
+
+  const result = source.getPackage('junk');
+  expect(result).toBeFalsy();
+});
+
+test('should list packages by key', async () => {
+  const source = new PackageLockSource(`
+  {
+    "name": "module",
+    "version": "0.0.1",
+    "dependencies": {
+      "Test Package": {
+        "version": "1.0.0"
+      },
+      "Test Package 2": {
+        "version": "2.0.0"
+      },
+      "Test Package 3": {
+        "version": "3.0.0"
+      }
+    }
+  }`);
+
+  const result = await source.listPackages();
+  expect(result).toEqual([
+    'Test Package 1.0.0',
+    'Test Package 2 2.0.0',
+    'Test Package 3 3.0.0',
+  ]);
+});
+
+test('should exclude dev by default', async () => {
+  const source = new PackageLockSource(`
+  {
+    "name": "module",
+    "version": "0.0.1",
+    "dependencies": {
+      "Test Package": {
+        "version": "1.0.0"
+      },
+      "Test Package 2": {
+        "version": "2.0.0",
+        "dev": true
+      },
+      "Test Package 3": {
+        "version": "3.0.0"
+      }
+    }
+  }`);
+
+  const result = await source.listPackages();
+  expect(result).toEqual(['Test Package 1.0.0', 'Test Package 3 3.0.0']);
+});
+
+test('should include dev by config', async () => {
+  const source = new PackageLockSource(
+    `
+  {
+    "name": "module",
+    "version": "0.0.1",
+    "dependencies": {
+      "Test Package": {
+        "version": "1.0.0"
+      },
+      "Test Package 2": {
+        "version": "2.0.0",
+        "dev": true
+      },
+      "Test Package 3": {
+        "version": "3.0.0"
+      }
+    }
+  }`,
+    false
+  );
+
+  const result = await source.listPackages();
+  expect(result).toEqual([
+    'Test Package 1.0.0',
+    'Test Package 2 2.0.0',
+    'Test Package 3 3.0.0',
+  ]);
+});
+
+test('should list packages recursively', async () => {
+  const source = new PackageLockSource(`
+  {
+    "name": "module",
+    "version": "0.0.1",
+    "dependencies": {
+      "Test Package": {
+        "version": "1.0.0",
+        "dependencies": {
+          "Test Package 2": {
+            "version": "2.0.0",
+            "dependencies": {
+              "Test Package 3": {
+                "version": "3.0.0"
+              }
+            }
+          }
+        }
+      }
+    }
+  }`);
+
+  const result = await source.listPackages();
+  expect(result).toEqual([
+    'Test Package 1.0.0',
+    'Test Package 2 2.0.0',
+    'Test Package 3 3.0.0',
+  ]);
+});

--- a/examples/packagelock-demo.js
+++ b/examples/packagelock-demo.js
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation and others.
+// SPDX-License-Identifier: Apache-2.0
+
+// This demo shows the package-lock.json file in this repo being run through the generator with a JSON output
+// This JSON output is transformed to a ClearlyDefined input and run through the generator again with a TEXT output
+
+const fs = require('fs');
+const path = require('path');
+const DocBuilder = require('../lib/docbuilder').default;
+const JsonRenderer = require('../lib/outputs/json').default;
+const TextRenderer = require('../lib/outputs/text').default;
+const PackageLockSource = require('../lib/inputs/packagelock').default;
+const ClearlyDefinedSource = require('../lib/inputs/clearlydefined').default;
+
+const jsonRenderer = new JsonRenderer();
+const jsonBuilder = new DocBuilder(jsonRenderer);
+const clearlyDefinedBuilder = new DocBuilder(new TextRenderer());
+
+const packageData = fs.readFileSync(
+  path.join(__dirname, '../package-lock.json')
+);
+
+const packageLockSource = new PackageLockSource(packageData);
+jsonBuilder
+  .read(packageLockSource)
+  .then(() => jsonBuilder.build())
+  .then(jsonOutput => {
+    const clearlydefinedInput = {
+      coordinates: jsonOutput.packages.map(
+        x =>
+          x.name.indexOf('/') > -1
+            ? `npm/npmjs/${x.name}/${x.version}`
+            : `npm/npmjs/-/${x.name}/${x.version}`
+      ),
+    };
+    return clearlyDefinedBuilder.read(
+      new ClearlyDefinedSource(JSON.stringify(clearlydefinedInput))
+    );
+  })
+  .then(() => {
+    const output = clearlyDefinedBuilder.build();
+    console.log(output);
+  });

--- a/inputs/packagelock.ts
+++ b/inputs/packagelock.ts
@@ -7,16 +7,9 @@ import { Package } from '../structure';
 export default class PackageLockSource implements MetadataSource {
   private packageMap: Map<string, Package>;
 
-  constructor(json: string) {
+  constructor(json: string, private readonly excludeDev = true) {
     const content = JSON.parse(json);
-    const dependencies = Object.keys(content.dependencies).map(x => {
-      return {
-        name: x,
-        version: content.dependencies[x].version,
-        text: '_',
-        isDev: content.dependencies[x].dev === true,
-      };
-    });
+    const dependencies = this.extractPackages(content.dependencies, []);
     const pkgkv = dependencies.map<[string, Package]>(p => [
       `${p.name} ${p.version}`,
       p,
@@ -31,4 +24,29 @@ export default class PackageLockSource implements MetadataSource {
   getPackage(id: string): Package | undefined {
     return this.packageMap.get(id);
   }
+
+  extractPackages(deps: dependencyNode, all: Package[]) {
+    if (!deps) return all;
+    Object.keys(deps).map(name => {
+      if (!this.excludeDev || !deps[name].dev) {
+        all.push({
+          name,
+          version: deps[name].version,
+          text: '_',
+        });
+      }
+      this.extractPackages(deps[name].dependencies, all);
+    });
+    return all;
+  }
+}
+
+interface dependencyNode {
+  [name: string]: dependency;
+}
+
+interface dependency {
+  version: string;
+  dev: boolean;
+  dependencies: dependencyNode;
 }

--- a/inputs/packagelock.ts
+++ b/inputs/packagelock.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation and others.
+// SPDX-License-Identifier: Apache-2.0
+
+import MetadataSource from './base';
+import { Package } from '../structure';
+
+export default class PackageLockSource implements MetadataSource {
+  private packageMap: Map<string, Package>;
+
+  constructor(json: string) {
+    const content = JSON.parse(json);
+    const dependencies = Object.keys(content.dependencies).map(x => {
+      return {
+        name: x,
+        version: content.dependencies[x].version,
+        text: '_',
+        isDev: content.dependencies[x].dev === true,
+      };
+    });
+    const pkgkv = dependencies.map<[string, Package]>(p => [
+      `${p.name} ${p.version}`,
+      p,
+    ]);
+    this.packageMap = new Map(pkgkv);
+  }
+
+  async listPackages(): Promise<string[]> {
+    return Array.from(this.packageMap.keys());
+  }
+
+  getPackage(id: string): Package | undefined {
+    return this.packageMap.get(id);
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
       tsConfigFile: 'tsconfig.json',
     },
   },
-  moduleFileExtensions: ['js', 'ts'],
+  moduleFileExtensions: ['js', 'ts', 'json'],
   testEnvironment: 'node',
   testMatch: ['**/__tests__/**/*.+(ts|tsx|js)'],
   testPathIgnorePatterns: ['node_modules', 'lib'],


### PR DESCRIPTION
*Description of changes:*

Adds a new input that takes package-lock.json files for npm projects
Added a demo that shows how this could be chained together with the ClearlyDefined Input

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
