### PR TITLE
filter clearlydefined files by nature

### DIFF
--- a/__tests__/inputs/clearlydefined.test.ts
+++ b/__tests__/inputs/clearlydefined.test.ts
@@ -72,6 +72,7 @@ test('should get license text', async () => {
         {
           path: 'LICENSE',
           token: 'thisisatoken',
+          natures: ['license'],
         },
       ],
       coordinates: { name: 'haslicense', revision: '1.0.0' },
@@ -86,6 +87,69 @@ test('should get license text', async () => {
     version: '1.0.0',
     license: 'MIT',
     text: 'THIS IS A LICENSE',
+    copyrights: undefined,
+    website: '',
+  });
+});
+
+test('should skip file by natures', async () => {
+  const source = new ClearlyDefinedSource(
+    JSON.stringify({
+      coordinates: [
+        'npm/npmjs/-/haslicense/1.0.0',
+        'npm/npmjs/-/hasfile/1.0.0',
+      ],
+    })
+  );
+  nockDefintions({
+    'npm/npmjs/-/haslicense/1.0.0': {
+      described: {},
+      licensed: {
+        declared: 'MIT',
+      },
+      files: [
+        {
+          path: 'LICENSE',
+          token: 'thisistoken1',
+          natures: ['license'],
+        },
+      ],
+      coordinates: { name: 'haslicense', revision: '1.0.0' },
+    },
+    'npm/npmjs/-/hasfile/1.0.0': {
+      described: {},
+      licensed: {
+        declared: 'MIT',
+      },
+      files: [
+        {
+          path: 'package.json',
+          token: 'thisistoken2',
+          natures: ['manifest'],
+        },
+      ],
+      coordinates: { name: 'hasfile', revision: '1.0.0' },
+    },
+  });
+  nockAttachments('thisistoken1', 'LICENSE first one');
+
+  await source.listPackages();
+  const result1 = source.getPackage('npm/npmjs/-/haslicense/1.0.0');
+  expect(result1).toEqual({
+    name: 'haslicense',
+    version: '1.0.0',
+    license: 'MIT',
+    text: 'LICENSE first one',
+    copyrights: undefined,
+    website: '',
+  });
+
+  const result2 = source.getPackage('npm/npmjs/-/hasfile/1.0.0');
+  expect(result2).toEqual({
+    name: 'hasfile',
+    version: '1.0.0',
+    license: 'MIT',
+    text: undefined,
     copyrights: undefined,
     website: '',
   });

--- a/__tests__/outputs/html.test.ts
+++ b/__tests__/outputs/html.test.ts
@@ -177,7 +177,7 @@ test('should encode angle brackets in license', () => {
 });
 
 const htmlFrame = (content: string) =>
-  `<!doctype html><html lang="en"><head><title>OSS Attribution</title><style>pre{white-space:pre-wrap;background:#eee;padding:24px}ol ol{list-style-type:lower-alpha}</style></head><body><h1>OSS Attribution</h1>${content}</body></html>`;
+  `<!DOCTYPE html><html lang="en"><head><title>OSS Attribution</title><meta charset="utf-8"><style>pre{white-space:pre-wrap;background:#eee;padding:24px}ol ol{list-style-type:lower-alpha}</style></head><body><h1>OSS Attribution</h1>${content}</body></html>`;
 
 test('should render custom template', () => {
   const htmlRenderer = new HtmlRenderer('NOTHING');


### PR DESCRIPTION
 - previously we were only harvesting license files in CD
 - now there are additional files such as package.json that get tokens


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
