### PR TITLE
Fix JSON output with missing package license text.

### DIFF
--- a/examples/packagelock-demo.js
+++ b/examples/packagelock-demo.js
@@ -26,11 +26,10 @@ jsonBuilder
   .then(() => jsonBuilder.build())
   .then(jsonOutput => {
     const clearlydefinedInput = {
-      coordinates: jsonOutput.packages.map(
-        x =>
-          x.name.indexOf('/') > -1
-            ? `npm/npmjs/${x.name}/${x.version}`
-            : `npm/npmjs/-/${x.name}/${x.version}`
+      coordinates: jsonOutput.packages.map(x =>
+        x.name.indexOf('/') > -1
+          ? `npm/npmjs/${x.name}/${x.version}`
+          : `npm/npmjs/-/${x.name}/${x.version}`
       ),
     };
     return clearlyDefinedBuilder.read(

--- a/src/outputs/json/index.ts
+++ b/src/outputs/json/index.ts
@@ -12,9 +12,16 @@ export default class JsonRenderer implements OutputRenderer<any> {
 
   render(buckets: LicenseBucket[]): any {
     return {
-      packages: buckets.map(x => x.packages).reduce((a, b) => {
-        return a.concat(b);
-      }, []),
+      packages: buckets
+        .map(x =>
+          x.packages.map(y => {
+            y.text = y.text == '' ? x.text : y.text;
+            return y;
+          })
+        )
+        .reduce((a, b) => {
+          return a.concat(b);
+        }, []),
     };
   }
 }


### PR DESCRIPTION
The bucket objects contain the license text for the packages in the bucket. The
other generators use the bucket text. Due to the hashing in the id of the
bucket map, all packages in the bucket have the same text. Some packages don't
have text and the default text is looked up in and added to the bucket, but not
the packages. The JSON generator was not using the bucket text. Also ran
lint:fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
